### PR TITLE
Add brew tap for maestro head

### DIFF
--- a/Formula/maestro-head.rb
+++ b/Formula/maestro-head.rb
@@ -1,0 +1,27 @@
+class MaestroHead < Formula
+  desc "Maestro CLI"
+  homepage "https://maestro.mobile.dev"
+  url "https://github.com/mobile-dev-inc/maestro/"
+  version "head"
+  license "Apache-2.0"
+
+  conflicts_with "mobile-dev-inc/tap/maestro", because: "This is the head version of maestro"
+  depends_on "openjdk@11"
+
+  head do
+    url "https://github.com/mobile-dev-inc/maestro.git", branch: "main"
+  end
+
+  def install
+    system "./gradlew", ":maestro-cli:installDist"
+
+    libexec.install Dir["maestro-cli/build/install/maestro/bin"]
+    lib = libexec + "lib"
+    lib.install Dir["**/build/**/*.jar"]
+    bin.install_symlink "#{libexec}/bin/maestro" => "maestro"
+  end
+
+  test do
+    shell_output("#{bin}/maestro --version")
+  end
+end


### PR DESCRIPTION
Usage:

Install latest head maestro:
`brew uninstall mobile-dev-inc/tap/maestro && brew install mobile-dev-inc/tap/maestro-head --HEAD`

Install current released maestro:
`brew uninstall mobile-dev-inc/tap/maestro-head && brew install mobile-dev-inc/tap/maestro`

Context:

Homebrew allows installing taps from releases, bottles and HEAD (current state of the repo).
JReleaser as far as I could find, does only support homebrew releases (not bottles nor HEAD installs).

The easiest way for us to support installing the latest HEAD using homebrew is to maintain a separate tap.
This PR adds the maestro-head tap so that one can (temporary) switch to the repo HEAD and back.
