### PR TITLE
feat: download jdk above 17 if nothing installed

### DIFF
--- a/Formula/maestro.rb
+++ b/Formula/maestro.rb
@@ -8,7 +8,7 @@ class Maestro < Formula
   sha256 "0b87a2eed8c1594fe572c5f29d6d64af389f4b7231ddde714179bbcb05f0fe0c"
   license "Apache-2.0"
 
-  depends_on "openjdk"
+  depends_on "openjdk" => "17+"
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
The goal here is to ensure Maestro installs a Java runtime that meets the new minimum requirement (JDK 17+). This change only applies for users who don’t already have Java installed — if a JDK is present, we still be in a situation where they might need to update to min 17 on their own.